### PR TITLE
Replace spaces with underscores in VM, etc names

### DIFF
--- a/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
+++ b/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
@@ -109,7 +109,7 @@ public class MetricsReceiver implements StatsListReceiver,
             String node;
             node = String.format(
                     "monitoring.nagios.%s.%s_%s",
-                    metricSet.getEntityName().replace("[vCenter]", "").replace("[VirtualMachine]", "").replace("[HostSystem]", "").replace('.', '_').replace('-', '_'),
+                    metricSet.getEntityName().replace("[vCenter]", "").replace("[VirtualMachine]", "").replace("[HostSystem]", "").replace('.', '_').replace('-', '_').replace(' ', '_'),
                     metricSet.getCounterName(),
                     metricSet.getStatType()
             );


### PR DESCRIPTION
vCloud Director and some humans put spaces in VM names.
