### PR TITLE
Graphite tree improvements, and instance leak bug fixed

### DIFF
--- a/sample/sampleConfig.xml
+++ b/sample/sampleConfig.xml
@@ -50,9 +50,13 @@
                     <name>host</name>
                     <value>metrics.zentrale.de</value>
                 </property>
-				<property>
+		<property>
                     <name>port</name>
                     <value>2003</value>
+                </property>
+		<property>
+                    <name>prefix</name>
+                    <value>esxprefix</value>
                 </property>
             </properties>
         </receiver>

--- a/sample/sampleConfig.xml
+++ b/sample/sampleConfig.xml
@@ -58,6 +58,21 @@
                     <name>prefix</name>
                     <value>esxprefix</value>
                 </property>
+		<property>
+                    <name>use_fqdn</name>
+                    <value>false</value>
+                </property>
+                <!--
+                    if "use_entity_type_prefix" is set to true the receiver will prepend the type
+                    [HostSystem]    => "esx".<hostname>
+                    [VirtuaMachine] => "vm".<vm_name>
+                    [Datastore]     => "dts".<datastore_name>
+                    [ResourcePool]  => "rp".<resource_pool_name>
+                 -->
+		<property>
+                    <name>use_entity_type_prefix</name>
+                    <value>true</value>
+                </property>
             </properties>
         </receiver>
     </receivers>

--- a/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
+++ b/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
@@ -108,6 +108,26 @@ public class MetricsReceiver implements StatsListReceiver,
         if(use_entity_type_prefix != null && !use_entity_type_prefix.isEmpty())
             this.use_entity_type_prefix=Boolean.valueOf(use_entity_type_prefix);
     }
+    
+    private String[] splitCounterName(String counterName) {
+        //should split string in a 3 componet array
+        // [0] = groupName
+        // [1] = metricName
+        // [2] = rollup
+        String[] result=new String[3];
+        String[] tmp=counterName.split("[.]");
+        //group Name
+        result[0]=tmp[0];
+        //rollup
+        result[2]=tmp[tmp.length-1];
+        result[1]=tmp[1];
+        if ( tmp.length > 3){
+         for(int i=2;i<tmp.length-1;++i) {
+            result[1]=result[1]+"."+tmp[i];
+            }
+        }
+        return result;
+    }
 
     /**
      * Main receiver entry point. This will be called for each entity and each metric which were retrieved by
@@ -165,15 +185,21 @@ public class MetricsReceiver implements StatsListReceiver,
             eName=eName.replace(' ','_').replace('-','_');
             
             if (instanceName.equals("")) {
-                node = String.format("%s.%s.%s_%s",graphite_prefix,eName,counterName,statType);
+                String[] counterInfo=splitCounterName(counterName);
+                String groupName    =counterInfo[0];
+                String metricName   =counterInfo[1];
+                String rollup       =counterInfo[2];
+                node = String.format("%s.%s.%s.%s_%s_%s",graphite_prefix,eName,groupName,metricName,rollup,statType);
                 logger.debug("GP :" +graphite_prefix+ " EN: "+eName+" CN :"+ counterName +" ST :"+statType);
             } else {
                 //Get group name (xxxx) metric name (yyyy) and rollup (zzzz) 
                 // from "xxxx.yyyyyy.xxxxx" on the metricName
-                String groupName=counterName.split("[.]",2)[0];
-                String metricName=counterName.split("[.]",2)[1];               
-                node = String.format("%s.%s.%s.%s.%s_%s",graphite_prefix,eName,groupName,instanceName,metricName,statType);
-                logger.debug("GP :" +graphite_prefix+ " EN: "+eName+" GN :"+ groupName +" IN :"+instanceName+" MN :"+metricName+" ST :"+statType);
+                String[] counterInfo=splitCounterName(counterName);
+                String groupName    =counterInfo[0];
+                String metricName   =counterInfo[1];
+                String rollup       =counterInfo[2];         
+                node = String.format("%s.%s.%s.%s.%s_%s_%s",graphite_prefix,eName,groupName,instanceName,metricName,rollup,statType);
+                logger.debug("GP :" +graphite_prefix+ " EN: "+eName+" GN :"+ groupName +" IN :"+instanceName+" MN :"+metricName+" RU"+rollup +"ST :"+statType);
             }
             
             //logger.debug("ENTITY NAME : " + entityName  +" ENTITY NAME2: "+metricSet.getEntityName()+ " COUNTER NAME: " + metricSet.getCounterName());

--- a/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
+++ b/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
@@ -29,6 +29,7 @@ public class MetricsReceiver implements StatsListReceiver,
     Log logger = LogFactory.getLog(MetricsReceiver.class);
 
     private String name = "SampleStatsReceiver";
+    private String graphite_prefix;
     private ExecutionContext context;
     private PrintStream writer;
     private Socket client;
@@ -90,6 +91,12 @@ public class MetricsReceiver implements StatsListReceiver,
     @Override
     public void setExecutionContext(ExecutionContext context) {
         this.context = context;
+        String prefix=this.props.getProperty("prefix");
+        if(prefix != null && !prefix.isEmpty())
+            this.graphite_prefix=this.props.getProperty("prefix");
+        else
+            this.graphite_prefix="vmware";
+
     }
 
     /**
@@ -108,11 +115,14 @@ public class MetricsReceiver implements StatsListReceiver,
             SDF.setTimeZone(TimeZone.getTimeZone("UTC"));
             String node;
             node = String.format(
-                    "monitoring.nagios.%s.%s_%s",
+                    "%s.%s.%s_%s",
+                    graphite_prefix,
                     metricSet.getEntityName().replace("[vCenter]", "").replace("[VirtualMachine]", "").replace("[HostSystem]", "").replace('.', '_').replace('-', '_').replace(' ', '_'),
                     metricSet.getCounterName(),
                     metricSet.getStatType()
             );
+            logger.debug("ENTITY NAME: "+metricSet.getEntityName()+ "COUNTER NAME:" + metricSet.getCounterName());
+            logger.debug("MOREF :"+metricSet.getMoRef()+ " INSTANCE ID :"+ metricSet.getInstanceId()+"string :"+metricSet.toString());
             try {
                 Iterator<PerfMetric> metrics = metricSet.getMetrics();
                 while (metrics.hasNext()) {


### PR DESCRIPTION
Added 3 new properties
- prefix
- use_fqdn
- use_entity_type_prefix 

Also added instance names (where available) on the metric path to correct this issue (https://github.com/SYNAXON/GraphiteReceiver/issues/4)
Added support for Datastore and ResourcePool metrics

By default all new parameters are set to maintain old metric path ( backwards compatibility) , but with the new parameters you can set this new graphite path

```
<prefix>.<entity_type>.<entity_name>.<metric_group>.<instance_name>.<counter_name>.<rollup>_<statistic_type>
```

**prefix**

any user defined string  "vmware.production." by example

**entity_type**

if "use_entity_type_prefix" is set to true the receiver will prepend the type to the entity_name
- [HostSystem]    => "esx".hostname
- [VirtuaMachine] => "vm".vm_name
- [Datastore]     => "dts".datastore_name
- [ResourcePool]  => "rp".resource_pool_name
  **entity_name**

the name of the host ESX , virtual machine , datastore or Resource Group.
if use_fqdn is set to false the receiver will remove domain information from the host.

**metric_group**

from the vijava sdk (http://vijava.sourceforge.net/vSphereAPIDoc/ver5/ReferenceGuide/vim.PerformanceManager.html)  the metric group are:  cpu,hbr,mem,managementAgent,net,power,sys,...etc.

**counter_name**

from the vijava sdk (http://vijava.sourceforge.net/vSphereAPIDoc/ver5/ReferenceGuide/vim.PerformanceManager.html)  , the name of the counter

**rollup**

from the vijava sdk (http://vijava.sourceforge.net/vSphereAPIDoc/ver5/ReferenceGuide/vim.PerformanceManager.html)  , the rollup of the metric

**statistic_type**

from the vijava sdk (http://vijava.sourceforge.net/vSphereAPIDoc/ver5/ReferenceGuide/vim.PerformanceManager.html)  , the estatistic type.
