### PR TITLE
Feature dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+GraphiteReceiver CHANGELOG
+==========================
+
+1.0-IPM-2
+---------
+- Nathan Haneysmith <nathan.haneysmith@nordstrom.com> - Sample Config w Prefix
+
+1.0-IPM-1
+---------
+- Nathan Haneysmith <nathan.haneysmith@nordstrom.com> - Adding customizable
+  prefix via config file
+
+1.0-IPM-3.2
+-----------
+- Lava Kumar <lava.a.basavapatna@nordstrom.com>
+- Changes Made:
+    : Modified to include cluster name in Graphite Streams. The interval for cache refreshment is configurable.
+    : The GraphiteReceiver connects to multiple Graphite Nodes in the backend (via port 2003). For effective load balancing
+      among multiple graphite-cyanite nodes, modified to support graphite server connection resets. This is configurable
+      attribute in config/graphite.xml.
+    : Look at README.md for alternative way of starting StatsFeeder server.
+

--- a/config/graphite.xml
+++ b/config/graphite.xml
@@ -1,0 +1,4 @@
+<!--
+    Copy GraphiteReceiver/sample/sampleConfig.xml file to GraphiteReceiver/config/graphite.xml file and make required changes.
+-->
+

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -1,0 +1,17 @@
+# Set root logger level to DEBUG and its only appender to statsfeeder.
+# Allowable logging Levels are: all|debug|info|warn|error|fatal|off|null
+log4j.rootLogger=INFO, statsfeeder
+
+# statsfeeder is set to be a ConsoleAppender.
+log4j.appender.statsfeeder=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.statsfeeder.File=/var/log/statsfeeder/statsfeeder-test.log
+log4j.appender.statsfeeder.DatePattern='.'MM-dd-yyyy
+log4j.appender.statsfeeder.MaxBackupIndex = 2 #14
+
+# statsfeeder uses PatternLayout.
+log4j.appender.statsfeeder.layout=org.apache.log4j.PatternLayout
+# this uses milliseconds
+# log4j.appender.statsfeeder.layout.ConversionPattern=%-4r [%t] %-5p %c{1} %x - %m%n
+# this uses localtime
+log4j.appender.statsfeeder.layout.ConversionPattern=%d [%t] %-5p %c{1} %x - %m%n
+

--- a/config/statsfeeder.properties
+++ b/config/statsfeeder.properties
@@ -1,0 +1,36 @@
+# Use this statsfeeder.properties file for configuring command line attributes required for StatsFeeder.
+# Refer /etc/init/statsfeeder-<datacenter>.conf file for usage of these attributes and start/stop statsfeeder.
+#
+# Alternatively you could use StatsFeeder.sh script comes with StatsFeeder-4.1.697.zip package.
+# 
+#
+#STATSFEEDER=<StatsFeeder Install Home Directory. Where all jar and config files are available>
+#
+STATSFEEDER=/opt/statsfeeder-test
+#
+
+# After you unzip StatsFeeder-4.1.697.zip or latest zip file from https://labs.vmware.com/flings/statsfeeder you will find all StatsFeeder jar files at lib folder. 
+# Copy the latest GraphiteReceiver StatsFeeder Plug-in jar file to lib folder. You may have to compile GraphiteReceiver source available at https://github.com/SYNAXON/GraphiteReceiver.
+#
+LIB_DIR=${STATSFEEDER}/lib
+
+# Log directory where you want to keep all log files. Please refer log4j.properties file for further details. This file is part of StatsFeeder-4.1.697.zip file.
+# To enable logging please include in the command run path.
+#
+LOG_DIR=/var/log/statsfeeder
+
+# The vCenter URL where StatsFeeder connects and receive performance metrics.
+VCS_HOST=
+
+# Required User Name and Password.
+VCS_USER=
+VCS_PASS=
+
+# The following lines are bing used to start StatsFeeder. It highlights required Java classpath and configs.
+#
+CLASSPATH=$(JARS=("$LIB_DIR"/*.jar); IFS=:; echo "${JARS[*]}")
+# Copy sample/sampleConfig.xml to config/graphite.xml and make required changes.
+CONFIG=$STATSFEEDER/config/graphite.xml
+LOGCONFIG=$STATSFEEDER/log4j.properties
+
+# End of statsfeeder.properties

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.synaxon</groupId>
-    <artifactId>GraphiteReceiver</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <artifactId>statsfeeder-GraphiteReceiver</artifactId>
+    <version>1.0-IPM-3.2</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -16,6 +16,11 @@
         <dependency>
             <groupId>com.vmware.tools</groupId>
             <artifactId>statsfeeder-common</artifactId>
+            <version>4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vmware.tools</groupId>
+            <artifactId>vsphere-sdk</artifactId>
             <version>4.1</version>
         </dependency>
         <dependency>

--- a/sample/sampleConfig.xml
+++ b/sample/sampleConfig.xml
@@ -54,6 +54,14 @@
                     <name>port</name>
                     <value>2003</value>
                 </property>
+    <property>
+                    <name>disconnection_graphite_after</name>
+                    <value>600000</value>
+                </property>
+    <property>
+                    <name>cache_refresh_interval</name>
+                    <value>3600</value>
+                </property>
 		<property>
                     <name>prefix</name>
                     <value>esxprefix</value>


### PR DESCRIPTION
Team,
I made following changes required for our project.
- Added ESX/VM to Cluster Map initialization. The cluster name becomes part of outgoing Graphite Message streams. To do that I have initialized the map and gets refreshed for every 1 hour (configured) or any new ESX/VM added during runtime.
  - Reset Graphite Server connection. This is required feature for us because in the backend we have multiple cyanite-graphite nodes (instances) balanced via HA proxy server. If we don't reset connection, then only one of many nodes get all messages. This reset connection happens during each receiveStats() call for configured messages. This is an optional feature and by default it's turned off.
- Synchronized receiveStats() method. During performance testing noticed server crash and graphite server was in hung state. After debugging core files noticed that PrintWriter Java APIs are not thread safe. Just synchronizing method and not optimizing the code for thread safe will not benefit. Therefore, we have decided to synchronize receiveStats method itself. There's no change in performance from the original implementation.
  - Added Debug statements in receiver java file for better documentation
  - Added config files for easy server setup and run on Linux servers. We thought this is very helpful for automations. Please note that all original implementations are supported and nothing is being altered.
