### PR TITLE
New order in node and Formatting and Performance Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.synaxon</groupId>
     <artifactId>statsfeeder-GraphiteReceiver</artifactId>
-    <version>1.0-IPM-3.3</version>
+    <version>1.0-IPM-3.4</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/sample/sampleConfig.xml
+++ b/sample/sampleConfig.xml
@@ -70,6 +70,10 @@
                     <name>use_fqdn</name>
                     <value>false</value>
                 </property>
+                <property>
+                    <name>place_rollup_in_the_end</name>
+                    <value>true</value>
+                </property>
 
                 <!--
                     if "use_entity_type_prefix" is set to true the receiver will prepend the type

--- a/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
+++ b/src/main/java/de/synaxon/graphitereceiver/MetricsReceiver.java
@@ -1,29 +1,29 @@
 package de.synaxon.graphitereceiver;
 
-        import com.vmware.ee.statsfeeder.ExecutionContext;
-        import com.vmware.ee.statsfeeder.PerfMetricSet;
-        import com.vmware.ee.statsfeeder.PerfMetricSet.PerfMetric;
-        import com.vmware.ee.statsfeeder.StatsExecutionContextAware;
-        import com.vmware.ee.statsfeeder.StatsFeederListener;
-        import com.vmware.ee.statsfeeder.StatsListReceiver;
-        import com.vmware.ee.statsfeeder.MOREFRetriever;
-        import java.io.IOException;
-        import java.io.OutputStream;
-        import java.io.PrintStream;
-        import java.io.PrintWriter;
-        import java.net.Socket;
-        import java.text.DateFormat;
-        import java.text.ParseException;
-        import java.text.SimpleDateFormat;
-        import java.util.Iterator;
-        import java.util.Properties;
-        import java.util.TimeZone;
-        import org.apache.commons.logging.Log;
-        import org.apache.commons.logging.LogFactory;
+import com.vmware.ee.statsfeeder.ExecutionContext;
+import com.vmware.ee.statsfeeder.PerfMetricSet;
+import com.vmware.ee.statsfeeder.PerfMetricSet.PerfMetric;
+import com.vmware.ee.statsfeeder.StatsExecutionContextAware;
+import com.vmware.ee.statsfeeder.StatsFeederListener;
+import com.vmware.ee.statsfeeder.StatsListReceiver;
+import com.vmware.ee.statsfeeder.MOREFRetriever;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.TimeZone;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
-        import com.vmware.vim25.*;
-        import com.vmware.ee.common.VimConnection;
-        import java.util.*;
+import com.vmware.vim25.*;
+import com.vmware.ee.common.VimConnection;
+import java.util.*;
 
 /**
  *
@@ -616,6 +616,8 @@ public class MetricsReceiver implements StatsListReceiver,
                  */
                 //Get group name (xxxx) metric name (yyyy) and rollup (zzzz)
                 // from "xxxx.yyyyyy.xxxxx" on the metricName
+                cluster = cluster.replace(".", "_");
+
                 String[] counterInfo = splitCounterName(counterName);
                 String groupName = counterInfo[0];
                 String metricName = counterInfo[1];


### PR DESCRIPTION
Hi . 

As @toni-moreno  proposed in https://github.com/SYNAXON/GraphiteReceiver/issues/17  I've coded the metric name reordering .

 In order to maintain backward compatibility I've created a new parameter  to switch metric order name.

```
                <property>
                    <name>place_rollup_in_the_end</name>
                    <value>true</value>
                </property>
```

I've also done minor performance improvements changing String Formatter by StringBuilder for creating metric names.

http://www.codetails.com/2012/10/30/why-is-stringbuilder-faster-in-string-concatenations/
