### PR TITLE
Added use_global_instance option

### DIFF
--- a/sample/sampleConfig.xml
+++ b/sample/sampleConfig.xml
@@ -91,6 +91,10 @@
                     <value>true</value>
                 </property>
                 <property>
+                    <name>use_global_instance</name>
+                    <value>true</value>
+                </property>
+                <property>
                     <name>names_transformation_rules</name>
                     <value>true</value>
                 </property>

--- a/src/main/java/de/synaxon/graphitereceiver/core/MetricsReceiver.java
+++ b/src/main/java/de/synaxon/graphitereceiver/core/MetricsReceiver.java
@@ -49,6 +49,7 @@ public class MetricsReceiver implements StatsListReceiver, StatsFeederListener, 
     private boolean only_one_sample_x_period;
     private boolean place_rollup_in_the_end;
     private boolean instanceMetrics;
+    private boolean globalInstance;
     private int disconnectCounter;
     private int disconnectAfter;
     private boolean isHostMap;
@@ -141,6 +142,12 @@ public class MetricsReceiver implements StatsListReceiver, StatsFeederListener, 
             this.instanceMetrics = Boolean.valueOf(this.props.getProperty("disable_instance_metrics"));
         } else {
             this.instanceMetrics = false;
+        }
+        
+        if(this.props.getProperty("use_global_instance") != null && !this.props.getProperty("use_global_instance").isEmpty()) {
+            this.globalInstance = Boolean.valueOf(this.props.getProperty("use_global_instance"));
+        } else {
+            this.globalInstance = false;
         }
 
         boolean isRules = false;
@@ -301,7 +308,11 @@ public class MetricsReceiver implements StatsListReceiver, StatsFeederListener, 
                 }
 
                 String instanceName = (this.rules.get("instanceName") != null)? RuleUtils.applyRules(metricSet.getInstanceId(),this.rules.get("instanceName")):metricSet.getInstanceId();
-
+                
+                if( ( this.globalInstance == true ) && ( instanceName == null || instanceName.isEmpty() ) )
+                {
+                        instanceName = "global";
+                }
 
                 String statType=metricSet.getStatType();
 


### PR DESCRIPTION
Added an option called use_global_instance option.

I found that when using disable_instance_metrics when combined with using InfluxDB, I was having problems with the templates that the Graphite listener for InfluxDB requires.

Specifically, I wanted to use this template:
"prefix.cluster.type.host.category.instance.measurement*",

However, when I allowed GraphiteReceiver to send instance stats, the instance name was empty for counters that don't have an instance, or the global one.

To make this template work for all metrics GraphiteReceiver sends, I modified GraphiteReceiver to replace the null instance name with the string "global" so that all metrics that came back had _something_ in the instance name and will fit with the InfluxDB Graphite listener template.

Then I added a configurable option to enable or disable this behavior, set to false by default so not to change the current behavior unless specifically configured.
